### PR TITLE
feat: Add YAML frontmatter injection for agent files

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -490,6 +490,26 @@ Then restart Claude Code and run `/setup` again.
 
 ---
 
+## Step 1.5: Configure Agent Files / ステップ1.5: エージェントファイルの設定
+
+**Action / アクション**: Add YAML frontmatter to agent files for Claude Code recognition:
+
+```typescript
+console.log('\n🔧 Configuring agents for Claude Code... / Claude Code用にエージェントを設定中...')
+
+const { execSync } = require('child_process')
+
+try {
+  execSync('bash .claude/scripts/add-frontmatter.sh', { stdio: 'inherit' })
+  console.log('✅ Agents configured successfully / エージェント設定が完了しました')
+} catch (error) {
+  console.log('⚠️  Warning: Could not configure agents / 警告: エージェント設定に失敗しました')
+  console.log('   This may happen if agents are already configured / エージェントが既に設定されている可能性があります')
+}
+```
+
+---
+
 ## Step 2: Auto-Detect Project Configuration / ステップ2: プロジェクト設定の自動検出
 
 Let me analyze your project to detect:

--- a/.claude/scripts/add-frontmatter.sh
+++ b/.claude/scripts/add-frontmatter.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+
+# EDAF v1.0 - Add YAML Frontmatter to Agent Files
+# This script adds the required YAML frontmatter to all agent and evaluator files
+# for Claude Code to recognize them as custom agents.
+
+set -e
+
+CLAUDE_DIR=".claude"
+AGENTS_DIR="$CLAUDE_DIR/agents"
+EVALUATORS_DIR="$CLAUDE_DIR/evaluators"
+
+# Color definitions
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}🔧 EDAF v1.0 - Adding YAML Frontmatter to Agents${NC}"
+echo ""
+
+# Function to add frontmatter to a file
+add_frontmatter() {
+  local file="$1"
+  local name="$2"
+  local description="$3"
+  local tools="$4"
+
+  # Check if file already has frontmatter
+  if head -n 1 "$file" | grep -q "^---$"; then
+    echo -e "${YELLOW}  ⚠️  Skipped: $name (already has frontmatter)${NC}"
+    return
+  fi
+
+  # Create temporary file with frontmatter
+  local temp_file="${file}.tmp"
+
+  cat > "$temp_file" << EOF
+---
+name: $name
+description: $description
+tools: $tools
+---
+
+EOF
+
+  # Append original content
+  cat "$file" >> "$temp_file"
+
+  # Replace original file
+  mv "$temp_file" "$file"
+
+  echo -e "${GREEN}  ✅ Added frontmatter: $name${NC}"
+}
+
+# Process Agents (Workers, Designer, Planner)
+echo -e "${BLUE}📋 Processing Agents...${NC}"
+
+if [ -f "$AGENTS_DIR/designer.md" ]; then
+  add_frontmatter \
+    "$AGENTS_DIR/designer.md" \
+    "designer" \
+    "Creates comprehensive design documents based on user requirements (Phase 1)" \
+    "Read, Write, Grep, Glob"
+fi
+
+if [ -f "$AGENTS_DIR/planner.md" ]; then
+  add_frontmatter \
+    "$AGENTS_DIR/planner.md" \
+    "planner" \
+    "Breaks down design documents into specific, actionable implementation tasks (Phase 2)" \
+    "Read, Write, Grep, Glob"
+fi
+
+if [ -f "$AGENTS_DIR/database-worker-v1-self-adapting.md" ]; then
+  add_frontmatter \
+    "$AGENTS_DIR/database-worker-v1-self-adapting.md" \
+    "database-worker-v1-self-adapting" \
+    "Auto-detects ORM and generates database models, migrations, and schemas" \
+    "Read, Write, Edit, Grep, Glob, Bash"
+fi
+
+if [ -f "$AGENTS_DIR/backend-worker-v1-self-adapting.md" ]; then
+  add_frontmatter \
+    "$AGENTS_DIR/backend-worker-v1-self-adapting.md" \
+    "backend-worker-v1-self-adapting" \
+    "Auto-detects framework and generates backend logic, APIs, and services" \
+    "Read, Write, Edit, Grep, Glob, Bash"
+fi
+
+if [ -f "$AGENTS_DIR/frontend-worker-v1-self-adapting.md" ]; then
+  add_frontmatter \
+    "$AGENTS_DIR/frontend-worker-v1-self-adapting.md" \
+    "frontend-worker-v1-self-adapting" \
+    "Auto-detects UI framework and generates frontend components and styles" \
+    "Read, Write, Edit, Grep, Glob, Bash"
+fi
+
+if [ -f "$AGENTS_DIR/test-worker-v1-self-adapting.md" ]; then
+  add_frontmatter \
+    "$AGENTS_DIR/test-worker-v1-self-adapting.md" \
+    "test-worker-v1-self-adapting" \
+    "Auto-detects testing framework and generates unit, integration, and E2E tests" \
+    "Read, Write, Edit, Grep, Glob, Bash"
+fi
+
+echo ""
+
+# Process Design Evaluators (Phase 1)
+echo -e "${BLUE}📊 Processing Design Evaluators (Phase 1)...${NC}"
+
+for evaluator in \
+  "design-consistency-evaluator:Evaluates design document for consistency across sections" \
+  "design-extensibility-evaluator:Evaluates design for future extensibility and flexibility" \
+  "design-goal-alignment-evaluator:Evaluates design alignment with project goals and requirements" \
+  "design-maintainability-evaluator:Evaluates design for long-term maintainability" \
+  "design-observability-evaluator:Evaluates design for monitoring and observability capabilities" \
+  "design-reliability-evaluator:Evaluates design for reliability and fault tolerance" \
+  "design-reusability-evaluator:Evaluates design for component reusability and modularity"
+do
+  IFS=':' read -r name desc <<< "$evaluator"
+  file="$EVALUATORS_DIR/${name}.md"
+
+  if [ -f "$file" ]; then
+    add_frontmatter \
+      "$file" \
+      "$name" \
+      "$desc (Phase 1: Design Gate)" \
+      "Read, Write, Grep, Glob"
+  fi
+done
+
+echo ""
+
+# Process Planner Evaluators (Phase 2)
+echo -e "${BLUE}📊 Processing Planner Evaluators (Phase 2)...${NC}"
+
+for evaluator in \
+  "planner-clarity-evaluator:Evaluates task plan for clarity and understandability" \
+  "planner-deliverable-structure-evaluator:Evaluates task plan deliverable structure and organization" \
+  "planner-dependency-evaluator:Evaluates task dependencies and execution order" \
+  "planner-goal-alignment-evaluator:Evaluates task plan alignment with design goals" \
+  "planner-granularity-evaluator:Evaluates task breakdown granularity and scope" \
+  "planner-responsibility-alignment-evaluator:Evaluates task-to-worker responsibility alignment" \
+  "planner-reusability-evaluator:Evaluates task plan for reusable components and patterns"
+do
+  IFS=':' read -r name desc <<< "$evaluator"
+  file="$EVALUATORS_DIR/${name}.md"
+
+  if [ -f "$file" ]; then
+    add_frontmatter \
+      "$file" \
+      "$name" \
+      "$desc (Phase 2: Planning Gate)" \
+      "Read, Write, Grep, Glob"
+  fi
+done
+
+echo ""
+
+# Process Code Evaluators (Phase 3)
+echo -e "${BLUE}📊 Processing Code Evaluators (Phase 3)...${NC}"
+
+for evaluator in \
+  "code-quality-evaluator-v1-self-adapting:Auto-detects linter/type checker and evaluates code quality" \
+  "code-testing-evaluator-v1-self-adapting:Auto-detects test framework and evaluates test coverage/quality" \
+  "code-security-evaluator-v1-self-adapting:Auto-detects security scanners and evaluates code security" \
+  "code-documentation-evaluator-v1-self-adapting:Auto-detects doc style and evaluates code documentation" \
+  "code-maintainability-evaluator-v1-self-adapting:Evaluates code maintainability and complexity" \
+  "code-performance-evaluator-v1-self-adapting:Evaluates code performance and efficiency" \
+  "code-implementation-alignment-evaluator-v1-self-adapting:Evaluates code alignment with design and requirements"
+do
+  IFS=':' read -r name desc <<< "$evaluator"
+  file="$EVALUATORS_DIR/${name}.md"
+
+  if [ -f "$file" ]; then
+    add_frontmatter \
+      "$file" \
+      "$name" \
+      "$desc (Phase 3: Code Review Gate)" \
+      "Read, Write, Grep, Glob, Bash"
+  fi
+done
+
+echo ""
+
+# Process Deployment Evaluators (Phase 4)
+echo -e "${BLUE}📊 Processing Deployment Evaluators (Phase 4)...${NC}"
+
+for evaluator in \
+  "deployment-readiness-evaluator:Evaluates deployment readiness and preparation" \
+  "production-security-evaluator:Evaluates production security configuration and hardening" \
+  "observability-evaluator:Evaluates monitoring, logging, and alerting setup" \
+  "performance-benchmark-evaluator:Evaluates performance benchmarks and optimization" \
+  "rollback-plan-evaluator:Evaluates rollback strategy and disaster recovery plan"
+do
+  IFS=':' read -r name desc <<< "$evaluator"
+  file="$EVALUATORS_DIR/${name}.md"
+
+  if [ -f "$file" ]; then
+    add_frontmatter \
+      "$file" \
+      "$name" \
+      "$desc (Phase 4: Deployment Gate)" \
+      "Read, Write, Grep, Glob, Bash"
+  fi
+done
+
+echo ""
+echo -e "${GREEN}✅ Frontmatter injection complete!${NC}"
+echo ""
+echo -e "${YELLOW}⚠️  IMPORTANT: Restart Claude Code to load the updated agents${NC}"
+echo -e "${YELLOW}⚠️  重要: 更新されたエージェントを読み込むためにClaude Codeを再起動してください${NC}"
+echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -90,12 +90,14 @@ else
   echo -e "${YELLOW}  ⚠️  Warning: setup.md not found (skipped) / 警告: setup.mdが見つかりません（スキップ）${NC}"
 fi
 
-# 7. Copy notification system
-echo -e "${BLUE}📋 Installing notification system... / 通知システムをインストール中...${NC}"
+# 7. Copy scripts (notification + frontmatter injection)
+echo -e "${BLUE}📋 Installing scripts... / スクリプトをインストール中...${NC}"
 if [ -d "$EDAF_DIR/.claude/scripts" ]; then
   cp -r $EDAF_DIR/.claude/scripts/* .claude/scripts/
   chmod +x .claude/scripts/*.sh 2>/dev/null
-  echo -e "${GREEN}  ✅ Notification scripts installed / 通知スクリプトをインストールしました${NC}"
+  echo -e "${GREEN}  ✅ Scripts installed / スクリプトをインストールしました${NC}"
+  echo -e "${GREEN}     - notification.sh (Sound notifications / 音声通知)${NC}"
+  echo -e "${GREEN}     - add-frontmatter.sh (Agent configuration / エージェント設定)${NC}"
 fi
 
 if [ -d "$EDAF_DIR/.claude/sounds" ]; then


### PR DESCRIPTION
## Summary

Adds YAML frontmatter to all agent and evaluator files to enable Claude Code recognition via Task tool.

## Changes

- **New script**: `.claude/scripts/add-frontmatter.sh`
  - Automatically injects YAML frontmatter to 32 files (6 agents + 26 evaluators)
  - Skips files that already have frontmatter
  - Provides clear output for each processed file

- **Updated**: `.claude/commands/setup.md`
  - Added Step 1.5 to call `add-frontmatter.sh` automatically
  - Users no longer need to manually configure agents

- **Updated**: `scripts/install.sh`
  - Now copies `add-frontmatter.sh` to target projects
  - Updated output to list all installed scripts

## Impact

✅ Fixes #2

After this PR:
- Task tool can invoke agents: `designer`, `planner`, workers, evaluators
- EDAF 4-phase gate system works as documented in CLAUDE.md
- Users get "agents configured successfully" message during `/setup`

## Testing

To test in a target project:
```bash
cd catchup-feed
bash evaluator-driven-agent-flow/scripts/install.sh
claude
/setup
```

After `/setup`, check that `.claude/agents/designer.md` starts with:
```yaml
---
name: designer
description: Creates comprehensive design documents...
tools: Read, Write, Grep, Glob
---
```

## Example Output

```
🔧 EDAF v1.0 - Adding YAML Frontmatter to Agents

📋 Processing Agents...
  ✅ Added frontmatter: designer
  ✅ Added frontmatter: planner
  ✅ Added frontmatter: database-worker-v1-self-adapting
  ...

📊 Processing Design Evaluators (Phase 1)...
  ✅ Added frontmatter: design-consistency-evaluator
  ...

✅ Frontmatter injection complete!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)