### PR TITLE
feat: Expand Docker command permissions in sandbox mode (#41)

### DIFF
--- a/.claude/settings.json.example
+++ b/.claude/settings.json.example
@@ -1,22 +1,28 @@
 {
   "permissions": {
     "allow": [
-      "Bash(docker compose exec:*)",
-      "Bash(docker-compose exec:*)"
+      "Bash(docker compose:*)",
+      "Bash(docker-compose:*)",
+      "Bash(docker build:*)",
+      "Bash(docker run:*)",
+      "Bash(docker ps:*)",
+      "Bash(docker logs:*)",
+      "Bash(docker images:*)"
     ],
     "deny": [
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git push:*)",
       "Bash(rm -rf:*)",
-      "Bash(git push --force:*)"
+      "Bash(git push --force:*)",
+      "Bash(docker rm:*)"
     ],
     "ask": []
   },
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,
-    "excludedCommands": ["git push", "rm -rf", "docker rm"]
+    "excludedCommands": ["git push", "rm -rf"]
   },
   "hooks": {
     "PermissionRequest": [


### PR DESCRIPTION
## Summary

- Expand Docker command permissions in `settings.json.example` to allow broader Docker commands in sandbox mode
- Add `docker rm:*` to deny list for container deletion safety
- Clean up redundant `excludedCommands` entry

## Changes

| Setting | Before | After |
|---------|--------|-------|
| **allow** | `docker compose exec:*`, `docker-compose exec:*` only | `docker compose:*`, `docker-compose:*`, `docker build:*`, `docker run:*`, `docker ps:*`, `docker logs:*`, `docker images:*` |
| **deny** | No docker rm | Added `docker rm:*` |
| **excludedCommands** | `["git push", "rm -rf", "docker rm"]` | `["git push", "rm -rf"]` |

## Test plan

- [ ] Verify Docker commands work in sandbox mode with new settings
- [ ] Verify `docker rm` is properly denied
- [ ] Verify other denied commands (git push, rm -rf) still blocked

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)