### PR TITLE
feat: Add explicit docker exec permissions to settings example

### DIFF
--- a/.claude/settings.json.example
+++ b/.claude/settings.json.example
@@ -1,6 +1,8 @@
 {
   "permissions": {
     "allow": [
+      "Bash(docker compose exec:*)",
+      "Bash(docker-compose exec:*)",
       "Bash(docker compose:*)",
       "Bash(docker-compose:*)",
       "Bash(docker build:*)",


### PR DESCRIPTION
## Summary
- Add `Bash(docker compose exec:*)` permission to allowed list
- Add `Bash(docker-compose exec:*)` permission to allowed list

This makes the docker exec permissions explicit in the example settings file for better clarity, alongside the existing `docker compose:*` and `docker-compose:*` patterns.

## Test plan
- [ ] Verify JSON syntax is valid
- [ ] Confirm permissions work as expected with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)